### PR TITLE
chore: remove dead live version link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 The Hexagon Grid Generator is a tool to create the HTML and CSS needed to display a responsive grid of hexagons.
 
-[live version](https://willemverbuyst.github.io/hexagon-grid-generator/)
-
 !['screenshot of the hexagon generator'](./img/hexagonGridGenerator.png)
 
 ![highlighted code](./img/highlighted-code.png)


### PR DESCRIPTION
Removed the link to the live version of the hexagon grid generator.

# PR Template

## Synopsis

## How does this work?

## How to test this PR?

## Checklist

- [x] Added label
